### PR TITLE
fix a buffer overflow

### DIFF
--- a/src/brf_entropy.c
+++ b/src/brf_entropy.c
@@ -257,7 +257,7 @@ static void *rx_stream_callback(struct bladerf *dev,
       }
       
       /* is buffer full? */
-      if (buffercounter > BUFFER_SIZE) {
+      if (buffercounter >= BUFFER_SIZE) {
 	/* We have 2500 bytes of entropy 
 	   Can now send it to FIPS! */
 	fips_result = fips_run_rng_test(&fipsctx, &bitbuffer);

--- a/src/rtl_entropy.c
+++ b/src/rtl_entropy.c
@@ -385,7 +385,7 @@ int main(int argc, char **argv) {
 	}
 	
 	/* is buffer full? */
-	if (buffercounter > BUFFER_SIZE) {
+	if (buffercounter >= BUFFER_SIZE) {
 	  /* We have 2500 bytes of entropy 
 	     Can now send it to FIPS! */
 	  fips_result = fips_run_rng_test(&fipsctx, &bitbuffer);


### PR DESCRIPTION
Assuming that the compiler places `bitbuffer_old` just behind `bitbuffer`, this buffer overflow is mostly harmless. But overwriting the first byte of the old buffer would break the xor-with-old scheme (whatever its purpose may be).
