### PR TITLE
Add long options and configuration file.  Add --quiet option to suppress messages.

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -19,6 +19,8 @@
 
 #define DEFAULT_PID_FILE "/var/run/rtl_entropy.pid"
 #define DEFAULT_OUT_FILE "/var/run/rtl_entropy.fifo"
+#define DEFAULT_CONFIGURATION_FILE_1      "/etc/rtl_entropy.conf"
+#define DEFAULT_CONFIGURATION_FILE_2      "/etc/sysconfig/rtl_entropy.conf"
 
 #define MHZ(x)	((x)*1000*1000)
 #define DEFAULT_SAMPLE_RATE		3200000

--- a/src/rtl_entropy.c
+++ b/src/rtl_entropy.c
@@ -119,7 +119,7 @@ void usage(void)
 #ifndef __APPLE__
   fprintf(stderr, "--user,          -u []  User to run as (default: rtl_entropy)\n");
 #endif
-  fprintf(stderr, "Configuration file at /etc/sysconfig/rtl_entropy has more detail and sample values.\n");
+  fprintf(stderr, "Configuration file at /etc/{,sysconfig/}rtl_entropy has more detail and sample values.\n");
   fprintf(stderr, "\n");
   exit(EXIT_SUCCESS);
 }

--- a/src/rtl_entropy.conf
+++ b/src/rtl_entropy.conf
@@ -1,0 +1,58 @@
+# This is the configuration file for the rtl-entropy application.  Options set here will be used instead of
+# program defaults, though they will be over-ridden by command line options.
+
+# Set the gain used for the dongle, with a default of max for the dongle.  The program uses the closest valid device
+# to the value entered.
+# The program prints out all the available gains for the device if --quiet is < 3.
+# This can also be found by running  rtl_test -t  if you have the librtlsdr installed, which is needed for rtl_entropy
+# to work.
+#-a 2.1
+--amplify=60.1
+
+# On non __APPLE__ systems, the program can be run as a daemon
+#-b
+#--daemonize
+
+# Device index, usually 0 if there is only one device, but if you have more you can choose here
+#-d 0
+#--device_idx=0
+
+# Obfuscate the output by using encryption on it
+#-e
+--encrypt
+
+# Request the frequency for the device to listen at.  Permissible suffixes are none (1) k (e3), M (e6), G (e9).
+#-f 101.5M
+--frequency=98.6M
+
+# On non __APPLE__ systems, run the program as this group.  Default is rtl_entropy
+#-g rtl_entropy
+#--group=rtl_entropy
+
+# Get the help message
+#-h
+#--help
+
+# This sets an output file to receive the output, rather than STDOUT.
+# In daemon mode, output goes to /var/run/rtl_entropy.fifo, by default.
+#-o high_entropy.bin
+#--output_file=high_entropy.bin
+
+# On non__APPLE__ systems, this sets the PID file to use.  Default is /var/run/rtl_entropy.pid
+#-p /var/run/rtl_entropy.pid
+#--pid_file=/var/run/rtl_entropy.pid
+
+# Set the quiet level, how much output to print, 0-3.  Default is 0, to print everything.
+# 1 doesn't print messages from the internal rngtest filter
+# 2 doesn't print info messages
+# 3 doesn't print any messages
+#-q 1
+--quiet=1
+
+# The rate at which to sample the device, the default is 2.4M
+#-s 2.6M
+--sample_rate=2.67M
+
+# On non __APPLE__ systems, this sets the user to run as.  Default is rtl_entropy
+#-u rtl_entropy
+#--user=rtl_entropy

--- a/src/rtl_entropy.conf
+++ b/src/rtl_entropy.conf
@@ -1,17 +1,22 @@
 # This is the configuration file for the rtl-entropy application.  Options set here will be used instead of
 # program defaults, though they will be over-ridden by command line options.
 
-# Set the gain used for the dongle, with a default of max for the dongle.  The program uses the closest valid device
-# to the value entered.
+# Set the gain used for the dongle, with a default of max for the dongle.  This is multiplied by 10 in the program
 # The program prints out all the available gains for the device if --quiet is < 3.
 # This can also be found by running  rtl_test -t  if you have the librtlsdr installed, which is needed for rtl_entropy
 # to work.
 #-a 2.1
---amplify=60.1
+#--amplify=2.1
+--amplify=60.0
 
 # On non __APPLE__ systems, the program can be run as a daemon
 #-b
 #--daemonize
+
+# This sets a config file to read for options to use rather than the defaults.
+# Default locations examined in order are /etc/rtl_entropy.conf and /etc/sysconfig/rtl_entropy.conf
+#-c /etc/rtl_entropy.conf
+#--config /etc/sysconfig/rtl_entropy.conf
 
 # Device index, usually 0 if there is only one device, but if you have more you can choose here
 #-d 0
@@ -19,11 +24,11 @@
 
 # Obfuscate the output by using encryption on it
 #-e
---encrypt
+--encrpyt
 
 # Request the frequency for the device to listen at.  Permissible suffixes are none (1) k (e3), M (e6), G (e9).
 #-f 101.5M
---frequency=98.6M
+--frequency=101.5M
 
 # On non __APPLE__ systems, run the program as this group.  Default is rtl_entropy
 #-g rtl_entropy


### PR DESCRIPTION
These two files add long options to rtl_entropy, a configuration file that should be placed in /etc/sysconfig/rtl_entropy, and a new option --quiet / -q that suppresses messages at different levels.  It defaults to 0, the current behavior.  But a 1 suppresses the messages from filtering, a 2 suppresses INFO messages, and a 3 suppresses all messages from rtl_entropy.

That's the only behavior change in the program.
