### PR TITLE
Delete rtl-entropy-docs.docs

### DIFF
--- a/debian/rtl-entropy-docs.docs
+++ b/debian/rtl-entropy-docs.docs
@@ -1,2 +1,0 @@
-README.source
-README.Debian


### PR DESCRIPTION
not needed, as the files are not there in debian/